### PR TITLE
Fix and improve regex regex

### DIFF
--- a/README.md
+++ b/README.md
@@ -370,7 +370,7 @@ const const email: RegExp<(?:[a-z0-9!#$%&'*+/=?^_`{|}~-]+(?:\.[a-z0-9!#$%&'*+/=?
 
 To avoid confusion, you can use any spelling that you want, such as `Regex`, `RegularExpression` and `RegExp`.
 
-For simplicity, all supported regular expressions match the regular expression `/Reg(ular)?[eE]x(pression|p)?/`.
+For simplicity, all supported regular expressions match the regular expression `/Reg(ular)?[eE]x(p(ression)?)?/`.
 
 ## Previous
 

--- a/README.md
+++ b/README.md
@@ -370,7 +370,7 @@ const const email: RegExp<(?:[a-z0-9!#$%&'*+/=?^_`{|}~-]+(?:\.[a-z0-9!#$%&'*+/=?
 
 To avoid confusion, you can use any spelling that you want, such as `Regex`, `RegularExpression` and `RegExp`.
 
-For simplicity, all supported regular expressions match the regular expression `/Reg(ular)?[eE]x(press|p)?/`.
+For simplicity, all supported regular expressions match the regular expression `/Reg(ular)?[eE]x(pression|p)?/`.
 
 ## Previous
 


### PR DESCRIPTION
The ion part of the regular expression regular expression was mistakenly removed after the regular expression regular expression was updated to allow writing regular express without the ion, in an improper reversal of said change, making regular expression with the ion no longer a valid keyword for a regular expression according to the regular expression regular expression, which I have now updated to not only include the ion but be more compact, reducing the pression or p to p with optional ression.