### PR TITLE
Better comment character : ((

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,20 @@ This includes numbers, and other language constructs.
 
 ```java
 const const 5 = 4!
-print(2 + 2 === 5)! //true
+print(2 + 2 === 5)! ((true
+```
+
+## Comments
+To encourage programmers to comment their code, Gulf of Mexico uses a character they have more muscle memory for. Comments are prefixed by ((
+
+```java
+print(1 + 1 = 2)! ((a relevant comment
+```
+
+Comments can be closed with the suffix )) in order to write them where they matter the most
+
+```java
+print( ((an int)) 1 + ((an other int)) 1 = ((a third int)) 2)!
 ```
 
 ## Arrays
@@ -110,9 +123,9 @@ Some languages start arrays at `0`, which can be unintuitive for beginners. Some
 
 ```java
 const const scores = [3, 2, 5]!
-print(scores[-1])! //3
-print(scores[0])!  //2
-print(scores[1])!  //5
+print(scores[-1])! ((3
+print(scores[0])!  ((2
+print(scores[1])!  ((5
 ```
 
 **New for 2022!**<br>
@@ -121,7 +134,7 @@ You can now use floats for indexes too!
 ```java
 const var scores = [3, 2, 5]!
 scores[0.5] = 4!
-print(scores)! //[3, 2, 4, 5]
+print(scores)! (([3, 2, 4, 5]
 ```
 
 ## When
@@ -140,20 +153,20 @@ when (health = 0) {
 Gulf of Mexico has a built-in garbage collector that will automatically clean up unused variables. However, if you want to be extra careful, you can specify a lifetime for a variable, with a variety of units.
 
 ```java
-const const name<2> = "Luke"! //lasts for two lines
-const const name<20s> = "Luke"! //lasts for 20 seconds
+const const name<2> = "Luke"! ((lasts for two lines
+const const name<20s> = "Luke"! ((lasts for 20 seconds
 ```
 
 By default, a variable will last until the end of the program. But you can make it last in between program-runs by specifying a longer lifetime.
 
 ```java
-const const name<Infinity> = "Luke"! //lasts forever
+const const name<Infinity> = "Luke"! ((lasts forever
 ```
 
 Variable hoisting can be achieved with this neat trick. Specify a negative lifetime to make a variable exist before its creation, and disappear after its creation.
 
 ```java
-print(name)! //Luke
+print(name)! ((Luke
 const const name<-1> = "Luke"!
 ```
 
@@ -193,8 +206,8 @@ function isKeyDown(key) => {
 Gulf of Mexico has significant whitespace. Use spacing to specify the order of arithmetic operations.
 
 ```java
-print(1 + 2*3)! //7
-print(1+2 * 3)! //9
+print(1 + 2*3)! ((7
+print(1+2 * 3)! ((9
 ```
 
 Gulf of Mexico proudly supports fractions!
@@ -206,7 +219,7 @@ const const half = 1/2!
 You can also use number names.
 
 ```java
-print(one + two)! //3
+print(one + two)! ((3
 ```
 
 ## Indents
@@ -234,28 +247,28 @@ JavaScript lets you do different levels of comparison. `==` for loose comparison
 You can use `==` to do a loose check.
 
 ```java
-3.14 == "3.14"! //true
+3.14 == "3.14"! ((true
 ```
 
 You can use `===` to do a more precise check.
 
 ```java
-3.14 === "3.14"! //false
+3.14 === "3.14"! ((false
 ```
 
 You can use `====` to be EVEN MORE precise!
 
 ```java
 const const pi = 3.14!
-print(pi ==== pi)! //true
-print(3.14 ==== 3.14)! //true
-print(3.14 ==== pi)! //false
+print(pi ==== pi)! ((true
+print(3.14 ==== 3.14)! ((true
+print(3.14 ==== pi)! ((false
 ```
 
 If you want to be much less precise, you can use `=`.
 
 ```java
-3 = 3.14! //true
+3 = 3.14! ((true
 ```
 
 ## Functions
@@ -276,7 +289,7 @@ f inverse(a) => 1/a!
 Dividing by zero returns `undefined`.
 
 ```java
-print(3 / 0)! //undefined
+print(3 / 0)! ((undefined
 ```
 
 ## Strings
@@ -380,8 +393,8 @@ Use it to get the previous value of a variable.
 ```java
 const var score = 5!
 score++!
-print(score)! //6
-print(previous score)! //5
+print(score)! ((6
+print(previous score)! ((5
 ```
 
 Similarly, the `next` keyword lets you see into the future.
@@ -389,14 +402,14 @@ Similarly, the `next` keyword lets you see into the future.
 ```java
 const var score = 5!
 addEventListener("click", () => score++)!
-print(await next score)! //6 (when you click)
+print(await next score)! ((6 (when you click)
 ```
 
 Additionally, the `current` keyword lets you see into the present.
 
 ```java
 const var score = 5!
-print(current score)! //5
+print(current score)! ((5
 ```
 
 ## File Structure
@@ -405,12 +418,12 @@ Write five or more equals signs to start a new file. This removes the need for m
 
 ```java
 const const score = 5!
-print(score)! //5
+print(score)! ((5
 
 =====================
 
 const const score = 3!
-print(score)! //3
+print(score)! ((3
 ```
 
 **New for 2022!**<br>
@@ -454,7 +467,7 @@ class Player {
 }
 
 const var player1 = new Player()!
-const var player2 = new Player()! //Error: Can't have more than one 'Player' instance!
+const var player2 = new Player()! ((Error: Can't have more than one 'Player' instance!
 ```
 
 This is how you could do it instead.
@@ -486,7 +499,7 @@ Date.now()!
 You can set the time.<br>
 
 ```java
-// Move the clocks back one hour
+(( Move the clocks back one hour
 Date.now() -= 3600000!
 ```
 
@@ -499,14 +512,14 @@ To avoid confusion, the `delete` statement only works with primitive values like
 
 ```java
 delete 3!
-print(2 + 1)! // Error: 3 has been deleted
+print(2 + 1)! (( Error: 3 has been deleted
 ```
 
 Gulf of Mexico is a multi-paradigm programming language, which means that you can `delete` the keywords and paradigms you don't like.
 
 ```java
 delete class!
-class Player {} // Error: class was deleted
+class Player {} (( Error: class was deleted
 ```
 
 When perfection is achieved and there is nothing left to `delete`, you can do this:
@@ -522,7 +535,7 @@ You can overload variables. The most recently defined variable gets used.
 ```java
 const const name = "Luke"!
 const const name = "Lu"!
-print(name)! // "Lu"
+print(name)! (( "Lu"
 ```
 
 Variables with more exclamation marks get prioritized.
@@ -530,10 +543,10 @@ Variables with more exclamation marks get prioritized.
 ```java
 const const name = "Lu"!!
 const const name = "Luke"!
-print(name)! // "Lu"
+print(name)! (( "Lu"
 
 const const name = "Lu or Luke (either is fine)"!!!!!!!!!
-print(name)! // "Lu or Luke (either is fine)"
+print(name)! (( "Lu or Luke (either is fine)"
 ```
 
 In the same spirit, you can use an inverted exclamation mark for negative priority.
@@ -541,7 +554,7 @@ In the same spirit, you can use an inverted exclamation mark for negative priori
 ```java
 const const name = "Lu"!
 const const name = "Luke"¡
-print(name)! // "Lu"
+print(name)! (( "Lu"
 ```
 
 ## Semantic naming
@@ -599,7 +612,7 @@ funct App() => {
 
 ```java
 funct App() => {
-   // This is not ok
+   (( This is not ok
    return <div class="greeting">Hello world!</div>
 }
 ```
@@ -608,7 +621,7 @@ funct App() => {
 
 ```java
 funct App() => {
-   // This is also not ok
+   (( This is also not ok
    return <div className="greeting">Hello world!</div>
 }
 ```
@@ -617,7 +630,7 @@ Instead, please use the `htmlClassName` attribute.
 
 ```java
 funct App() => {
-   // This is fine
+   (( This is fine
    return <div htmlClassName="greeting">Hello world!</div>
 }
 ```
@@ -641,8 +654,8 @@ Gulf of Mexico now supports rich text.
 const const <b>name</b> = "Lu"!
 const const <i>name</i> = "Luke"!
 
-print(<b>name</b>)! // Lu
-print(<i>name</i>)! // Luke
+print(<b>name</b>)! (( Lu
+print(<i>name</i>)! (( Luke
 </pre>
 
 Rich text can be helpful when making your website. Use it to add links!
@@ -696,8 +709,8 @@ In GulfOfMexico, you can set (and get) signals with just one function:
 ```java
 const var score = use(0)!
 
-score(9)! // Set the value
-score()?  // Get the value (and print it)
+score(9)! (( Set the value
+score()?  (( Get the value (and print it)
 ```
 
 Alternatively, you can be more explicit with your signal syntax, by splitting it into a getter and setter.
@@ -705,8 +718,8 @@ Alternatively, you can be more explicit with your signal syntax, by splitting it
 ```java
 const var [getScore, setScore] = use(0)!
 
-setScore(9)! // Set the value
-getScore()?  // Get the value (and print it)
+setScore(9)! (( Set the value
+getScore()?  (( Get the value (and print it)
 ```
 
 **Technical info:** This is pure syntax sugar. The split signal functions are exactly the same as before.
@@ -714,8 +727,8 @@ getScore()?  // Get the value (and print it)
 ```java
 const var [getScore, setScore] = use(0)!
 
-getScore(9)! // Set the value
-setScore()?  // Get the value (and print it)
+getScore(9)! (( Set the value
+setScore()?  (( Get the value (and print it)
 ```
 
 This means that you can carry on splitting as much as you like.
@@ -729,19 +742,19 @@ const var [[[getScore, setScore], setScore], setScore] = use(0)!
 Gulf of Mexico features AEMI, which stands for Automatic-Exclamation-Mark-Insertion. If you forget to end a statement with an exclamation mark, Gulf of Mexico will helpfully insert one for you!
 
 ```java
-print("Hello world") // This is fine
+print("Hello world") (( This is fine
 ```
 
 Similarly... Gulf of Mexico also features ABI, which stands for Automatic-Bracket-Insertion. If you forget to close your brackets, Gulf of Mexico will pop some in for you!
 
 ```java
-print("Hello world" // This is also fine
+print("Hello world" (( This is also fine
 ```
 
 Similarly.... Gulf of Mexico also features AQMI, which stands for Automatic-Quotation-Marks-Insertion. If you forget to close your string, Gulf of Mexico will do it for you!
 
 ```java
-print("Hello world // This is fine as well
+print("Hello world (( This is fine as well
 ```
 
 This can be very helpful in callback hell situations!
@@ -751,14 +764,14 @@ addEventListener("click", (e) => {
    requestAnimationFrame(() => {
       print("You clicked on the page
 
-      // This is fine
+      (( This is fine
 ```
 
 Similarly..... Gulf of Mexico also features AI, which stands for Automatic-Insertion.<br>
 If you forget to finish your code, Gulf of Mexico will auto-complete the whole thing!
 
 ```java
-print( // This is probably fine
+print( (( This is probably fine
 ```
 
 **Please note:** AI does not use AI. Instead, any incomplete code will be auto-emailed to [Lu Wilson](https://todepond.com), who will get back to you with a completed line as soon as possible.
@@ -813,7 +826,7 @@ This is what the highlighting looks like:
 
 ```
 const const name = "Luke"!
-print(name)! // "Luke"
+print(name)! (( "Luke"
 ```
 
 **Please note:** The above code will only highlight correctly if you have the extension installed.
@@ -822,7 +835,7 @@ print(name)! // "Luke"
 
 Wait, I almost forgot!
 
-Parentheses in Gulf of Mexico do nothing. They get replaced with whitespace. Everything is grouped via significant whitespace. The following lines of code all do the exact same thing.
+Beside marking comments, Parentheses in Gulf of Mexico do nothing. They get replaced with whitespace. Everything is grouped via significant whitespace. The following lines of code all do the exact same thing.
 
 ```java
 add(3, 2)!


### PR DESCRIPTION
This change will help programers to make more frequent comments by using a key they are more used to : ((

I also changed every // comment in the documentation with ((
However the syntax highlighting does not work with theses new comment characters (yet)

feel free to tweak the idea, implementation and documentation to your liking :)