### PR TITLE
Update contributor graph links

### DIFF
--- a/README.md
+++ b/README.md
@@ -864,7 +864,7 @@ Gulf of Mexico was made with 💔 by [Lu or Luke (either's fine) Wilson](https:/
 
 <br>
 
-<a href="https://github.com/todepond/dreamberd/graphs/contributors">
-  <img src="https://contrib.rocks/image?repo=todepond/dreamberd&max=999&columns=12" width="100%"/>
+<a href="https://github.com/todepond/GulfOfMexico/graphs/contributors">
+  <img src="https://contrib.rocks/image?repo=todepond/GulfOfMexico&max=999&columns=12" width="100%"/>
 </a>
 


### PR DESCRIPTION
We must always strive to erase our history. Those that don't learn from history are doomed to repeat it and we should repeat history.

This updates the link to the contributor graphs to not mention dreamberd. Instead to use GulfOfMexico. Who would ever want to refer to something by its old, outdated name that the rest of the planet still refers to it as?