### PR TITLE
Fixed inaccuracy related to function construct

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,7 +260,7 @@ If you want to be much less precise, you can use `=`.
 
 ## Functions
 
-To declare a function, you can use any letters from the word `function` (as long as they're in order):
+To declare a function, you can use any letters from the word `function`:
 
 ```java
 function add(a, b) => a + b!


### PR DESCRIPTION
This "as long as it's in order" statement is incorrect. The counter example is `fn` which from the example is a valid construction to define a function. Note: `fn` are letters in `function` but not in order.

Therefore, this qualification should be removed (or the example should be removed if it is out of spec)